### PR TITLE
Fix edge case for zero-length decoration in empty leaf.

### DIFF
--- a/packages/slate/src/interfaces/text.ts
+++ b/packages/slate/src/interfaces/text.ts
@@ -113,8 +113,12 @@ export const Text: TextInterface = {
         const offset = o
         o += length
 
-        // If the range encompases the entire leaf, add the range.
-        if (start.offset <= offset && end.offset >= o) {
+        // If the range encompases the entire leaf (and the range is non-empty), add the range.
+        if (
+          start.offset <= offset &&
+          end.offset >= o &&
+          start.offset < end.offset
+        ) {
           Object.assign(leaf, rest)
           next.push(leaf)
           continue


### PR DESCRIPTION
This change ensures that a zero-length decoration is never treated as encompassing the entire leaf,
handling an edge case where an empty decoration inside an empty leaf was being treated
as encompassing the entire leaf and thus preventing the "before" and "after" leaves
we would otherwise see (when a zero-length decoration is applied to any non-empty leaf).

This fixes issues encountered in the `slate-page-decorations` library for the edge case
of an empty paragraph node being located on the edge of a page boundary.

In such cases the cursor would disappear because the "before" and "after" leaves were gone,
with only the decoration leaf (which renders as a `span contentEditable=false`) was in that element,
causing the element to have no selectable leaves.

